### PR TITLE
DEVPROD-6063: update to macos 11

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -67,10 +67,10 @@ buildvariants:
       - name: "sign_msi"
         run_on: ubuntu2204-large
   - name: macos
-    display_name: OSX 10.14
+    display_name: OSX 11
     expansions:
       _platform: macos
-    run_on: macos-1014
+    run_on: macos-1100
     tasks:
       - name: "build"
       - name: "unit_tests"


### PR DESCRIPTION
10.14 is long past EOL, and we should upgrade before 10.14 is removed from our CI. I tested bumping to MacOS 14, but ran into an error along the way. MacOS 11 is also EOL, but not quite as old as 10.14 and buys us a bit more time. This change has passed a patch build's MacOS tasks.

Note that we're still using MacOS 10.14 for codesigning for now. That will have to be a separate migration, but this change puts us one step closer to removal of 10.14 globally at least.