### PR TITLE
BI-2859: Fix pulling latest libmongosql dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mongodb-odbc-driver/libmongosql"]
 	path = mongodb-odbc-driver/libmongosql
-	url = git@github.com:mongodb/libmongosql
+        url = https://github.com/mongodb/libmongosql


### PR DESCRIPTION
Changed the cloning url to use Https since ssh is not working anymore.
Also updated to use the latest version of libmongosql.