### PR TITLE
[SQL-3378] Cap byte copies to buffer size

### DIFF
--- a/driver/catalog_no_i_s.c
+++ b/driver/catalog_no_i_s.c
@@ -1817,7 +1817,8 @@ procedure_columns_no_i_s(SQLHSTMT hstmt,
 
       token= proc_get_param_type(token, (int)strlen(token), &ptype);
       token= proc_get_param_name(token, (int)strlen(token), param_name);
-      token= proc_get_param_dbtype(token, (int)strlen(token), param_dbtype);
+      token= proc_get_param_dbtype(token, (int)strlen(token), param_dbtype,
+                                   sizeof(param_dbtype));
 
       /* param_dbtype is lowercased in the proc_get_param_dbtype */
       if (strstr(param_dbtype, "unsigned"))

--- a/driver/myutil.h
+++ b/driver/myutil.h
@@ -333,7 +333,8 @@ enum enum_field_types map_sql2mysql_type(SQLSMALLINT sql_type);
 char *      proc_param_tokenize   (char *str, int *params_num);
 SQLCHAR *   proc_get_param_type   (SQLCHAR *proc, int len, SQLSMALLINT *ptype);
 SQLCHAR*    proc_get_param_name   (SQLCHAR *proc, int len, SQLCHAR *cname);
-SQLCHAR*    proc_get_param_dbtype (SQLCHAR *proc, int len, SQLCHAR *ptype);
+SQLCHAR*    proc_get_param_dbtype (SQLCHAR *proc, int len, SQLCHAR *ptype,
+                                   size_t ptype_size);
 SQLUINTEGER proc_get_param_size   (SQLCHAR *ptype, int len, int sql_type_index,
                                   SQLSMALLINT *dec);
 SQLLEN      proc_get_param_octet_len  (STMT *stmt, int sql_type_index,

--- a/driver/utility.c
+++ b/driver/utility.c
@@ -3194,18 +3194,37 @@ SQLCHAR* proc_get_param_name(SQLCHAR *proc, int len, SQLCHAR *cname)
   @param[in]  proc        procedure parameter string
   @param[in]  len         param string length
   @param[out] cname       pointer where to write the param type name
+  @param[in]  ptype_size  size of the ptype buffer in bytes, including room
+                          for the terminating NUL
 
   Returns position in the param string after parameter type name
 */
-SQLCHAR* proc_get_param_dbtype(SQLCHAR *proc, int len, SQLCHAR *ptype)
+SQLCHAR* proc_get_param_dbtype(SQLCHAR *proc, int len, SQLCHAR *ptype,
+                               size_t ptype_size)
 {
   char *trim_str, *start_pos= ptype;
+  /* Reserve one byte for the terminating NUL. */
+  size_t remaining_buffer_size= (ptype_size != 0) ? ptype_size - 1 : 0;
+
+  if (ptype_size == 0)
+    return proc;
 
   while (isspace(*proc) && (len--))
     ++proc;
 
-  while (*proc && (len--) )
+  while (*proc && (len--) && remaining_buffer_size > 0)
+  {
     *(ptype++)= *(proc++);
+    --remaining_buffer_size;
+  }
+
+  /*
+    Terminate unconditionally, on every path. `ptype` points just past the last
+    byte copied, at most index `ptype_size - 1`, because the loop above reserved
+    a byte for the NUL. A server-supplied type longer than the buffer is
+    truncated here instead of overflowing it.
+  */
+  *ptype= 0;
 
   /* remove the character set definition */
   if (trim_str= strstr( myodbc_strlwr(start_pos, 0),
@@ -3214,13 +3233,17 @@ SQLCHAR* proc_get_param_dbtype(SQLCHAR *proc, int len, SQLCHAR *ptype)
     ptype= trim_str;
     (*ptype)= 0;
   }
-  
-  /* trim spaces from the end */
-  ptype-=1;
-  while (isspace(*(ptype)))
+
+  /*
+    Trim spaces from the end. Each step moves the terminator back one byte, so
+    the buffer stays a valid C string on every iteration. The `ptype >
+    start_pos` guard keeps an all-whitespace or empty type from walking the
+    pointer below the start of the caller's buffer.
+  */
+  while (ptype > start_pos && isspace(*(ptype - 1)))
   {
-    *ptype= 0;
     --ptype;
+    *ptype= 0;
   }
 
   return proc;


### PR DESCRIPTION
## Summary                                                                                                                              
                                                                                                                                       
Caps copy in the proc_get_param_dbtype by the size of the buffer to avoid buffer overflow.                                                           
                                                                                                                                       
## Changes                                                                                                                              
                                                                                                                                       
- proc_get_param_dbtype now takes an explicit ptype_size capacity, caps the copy at one byte less than that, leaving space for a null terminator. The function now has a variable, remaining_buffer_size, to avoid buffer overflow.
       