### PR TITLE
[BI-3317] Add bounds check to get_limit method

### DIFF
--- a/driver/utility.c
+++ b/driver/utility.c
@@ -3972,7 +3972,8 @@ char* get_limit_numbers(CHARSET_INFO* cs, char *query, char * query_end,
     ++query;
   
   // Collect all numbers for the offset
-  while ((query_end > query) && myodbc_isnum(cs, query, query_end))
+  while (index_pos < (int)sizeof(digit_buf) - 1 &&
+         (query_end > query) && myodbc_isnum(cs, query, query_end))
   {
     digit_buf[index_pos] = *query;
     ++index_pos;
@@ -4004,7 +4005,8 @@ char* get_limit_numbers(CHARSET_INFO* cs, char *query, char * query_end,
   index_pos = 0; // reset index to use with another number
 
   // Collect all numbers for the row number
-  while ((query_end > query) && myodbc_isnum(cs, query, query_end))
+  while (index_pos < (int)sizeof(digit_buf) - 1 &&
+         (query_end > query) && myodbc_isnum(cs, query, query_end))
   {
     digit_buf[index_pos] = *query;
     ++index_pos;

--- a/driver/utility.c
+++ b/driver/utility.c
@@ -3971,12 +3971,15 @@ char* get_limit_numbers(CHARSET_INFO* cs, char *query, char * query_end,
   while ((query_end > query) && myodbc_isspace(cs, query, query_end))
     ++query;
   
-  // Collect all numbers for the offset
-  while (index_pos < (int)sizeof(digit_buf) - 1 &&
-         (query_end > query) && myodbc_isnum(cs, query, query_end))
+  // Collect all numbers for the offset. Keep consuming digits even after
+  // digit_buf is full so `query` always ends up past the entire digit run.
+  while ((query_end > query) && myodbc_isnum(cs, query, query_end))
   {
-    digit_buf[index_pos] = *query;
-    ++index_pos;
+    if (index_pos < (int)sizeof(digit_buf) - 1)
+    {
+      digit_buf[index_pos] = *query;
+      ++index_pos;
+    }
     ++query;
   }
 
@@ -4004,12 +4007,15 @@ char* get_limit_numbers(CHARSET_INFO* cs, char *query, char * query_end,
 
   index_pos = 0; // reset index to use with another number
 
-  // Collect all numbers for the row number
-  while (index_pos < (int)sizeof(digit_buf) - 1 &&
-         (query_end > query) && myodbc_isnum(cs, query, query_end))
+  // Collect all numbers for the row number. Keep consuming digits even after
+  // digit_buf is full so `query` always ends up past the entire digit run.
+  while ((query_end > query) && myodbc_isnum(cs, query, query_end))
   {
-    digit_buf[index_pos] = *query;
-    ++index_pos;
+    if (index_pos < (int)sizeof(digit_buf) - 1)
+    {
+      digit_buf[index_pos] = *query;
+      ++index_pos;
+    }
     ++query;
   }
 


### PR DESCRIPTION
Add bounds check to get_limit method up to the size of the buffer.

The two updated loops update values in the digit_buf array without actually keeping track of its length. Update the code to ensure we stay in bounds for the digit_buf. 

Note that we included the code inside the while loop rather than as a loop condition because the query is typically longer than the digits.